### PR TITLE
"win32" -> "windows" in ppctools.py

### DIFF
--- a/mgc/pyiiasmh/ppctools.py
+++ b/mgc/pyiiasmh/ppctools.py
@@ -46,7 +46,7 @@ def setup():
     eabi['objcopy'] = platform_folder/("powerpc-eabi-objcopy" + file_extension)
 
 def asm_opcodes(tmpdir, txtfile=None, binfile=None):
-    if platform.system().lower() not in ("darwin", "linux", "win32"):
+    if platform.system().lower() not in ("darwin", "linux", "windows"):
         raise UnsupportedOSError("'" + platform.system() + "' os is not supported")
     for i in ("as", "ld", "objcopy"):
         if not eabi[i].exists():

--- a/mgc/pyiiasmh/ppctools.py
+++ b/mgc/pyiiasmh/ppctools.py
@@ -46,11 +46,9 @@ def setup():
     eabi['objcopy'] = platform_folder/("powerpc-eabi-objcopy" + file_extension)
 
 def asm_opcodes(tmpdir, txtfile=None, binfile=None):
-    if platform.system().lower() not in ("darwin", "linux", "windows"):
-        raise UnsupportedOSError("'" + platform.system() + "' os is not supported")
     for i in ("as", "ld", "objcopy"):
         if not eabi[i].exists():
-            raise IOError(eabi[i].name + " not found")
+            raise IOError(str(eabi[i]) + " not found")
 
     if txtfile is None:
         txtfile = tmpdir.joinpath("code.txt")


### PR DESCRIPTION
this allows ASM compilation to succeed on Windows (at least on my machine, otherwise I see `Error compiling ASM: "'Windows' os is not supported"`)