### PR TITLE
Various new features and fixes to make 20XXTE source port possible

### DIFF
--- a/doc/basics.txt
+++ b/doc/basics.txt
@@ -63,6 +63,10 @@ unique ways.
     will work equally well, because they're just hex anyway. If not using
     !geckocodelist, make sure your Gecko codeset begins with "00d0c0de 00d0c0de"
     and ends with "f0000000 00000000".
+!fill 0x120 ff
+    Fills the pattern in the second argument the number of times in the first
+    argument. The pattern can be hex (eg. ff) or binary (eg. %11111111). It can
+    be any number of bytes long.
 !string "This is a text string"
     Adds a raw ASCII text string to Melee memory. Escape characters are honored,
     so using \n in a text string will appropriately write 0xa into memory.

--- a/doc/basics.txt
+++ b/doc/basics.txt
@@ -34,6 +34,8 @@ unique ways.
 !loc 8045f000
 	Denotes where to inject any following data in Melee memory, until the next
 	location is specified.
+    Lower bound: 8045bf28
+    Upper bound: 8046b0f0
 !gci 4f50
 	Advanced usage only - lets you specify a GCI offset location rather than a
 	Melee memory location to inject data to. You'll almost always want to use

--- a/doc/basics.txt
+++ b/doc/basics.txt
@@ -8,22 +8,22 @@ STANDARD OPERATIONS
 -------------------
 
 0123456789ABCDEF
-	All standalone hex is written to Melee memory as-is. Whitespace is ignored,
-	so formats like "0D 15 3A 5E" and "c2380580 00000006" are fine too. It is
-	also not case-sensitive.
+    All standalone hex is written to Melee memory as-is. Whitespace is ignored,
+    so formats like "0D 15 3A 5E" and "c2380580 00000006" are fine too. It is
+    also not case-sensitive.
 %10010110
-	Lines beginning with '%' denote binary instead of hex.
+    Lines beginning with '%' denote binary instead of hex.
 +macro_name 10
-	Runs a macro that was defined using !macro (see Special Commands). Optional
-	count argument specifies how many times to run the macro, eg. 10 (ten) or
-	0x10 (sixteen) times.
+    Runs a macro that was defined using !macro (see Special Commands). Optional
+    count argument specifies how many times to run the macro, eg. 10 (ten) or
+    0x10 (sixteen) times.
 [alias_name]
-	Gets replaced by the data specified using !define (see Special Commands).
+    Gets replaced by the data specified using !define (see Special Commands).
 # Comment
-	Anything after '#' on a line is a comment and ignored by the compiler.
+    Anything after '#' on a line is a comment and ignored by the compiler.
 /* ... */
-	Multi-line comment. Anything between the comment tags is ignored by the
-	compiler.
+    Multi-line comment. Anything between the comment tags is ignored by the
+    compiler.
 
 
 SPECIAL COMMANDS
@@ -32,55 +32,62 @@ Commands give the compiler special information or allow you to load data in
 unique ways.
 
 !loc 8045f000
-	Denotes where to inject any following data in Melee memory, until the next
-	location is specified.
+    Denotes where to inject any following data in Melee memory, until the next
+    location is specified.
     Lower bound: 8045bf28
     Upper bound: 8046b0f0
 !gci 4f50
-	Advanced usage only - lets you specify a GCI offset location rather than a
-	Melee memory location to inject data to. You'll almost always want to use
-	!loc to specify where in Melee memory you want the data to go, rather than
-	worry about where it goes in the GCI.
+    Advanced usage only - lets you specify a GCI offset location rather than a
+    Melee memory location to inject data to. You'll almost always want to use
+    !loc to specify where in Melee memory you want the data to go, rather than
+    worry about where it goes in the GCI.
+!patch 4f50
+    Advanced usage only - like !gci, but writing data while in patch mode defers
+    that data from being written until the very end of compilation, right before
+    the GCI is packed. If !blockorder is used, block reordering happens before
+    this as well. Using !loc or !gci after !patch will disable patch mode for
+    following data writes.
 !add 1a0
-	Adds a relative amount to the loc pointer.
+    Adds a relative amount to the loc pointer.
 !src "path/to/source"
-	Adds the given MGC script file to the build script at that location.
+    Adds the given MGC script file to the build script at that location.
 !asmsrc "path/to/source"
-	Compiles and adds the ASM source file to the current location.
+    Compiles and adds the ASM source file to the current location.
 !file "path/to/file"
-	Adds the entire binary file directly to Melee memory.
+    Adds the entire binary file directly to Melee memory.
 !geckocodelist "path/to/codelist"
-	Compiles the Gecko codelist text file, then adds the resulting binary to
-	Melee memory. Gecko codelists have their own format that is not covered
-	here. This command is for convenience purposes only for those using Gecko
-	codelist files, but adding your Gecko codes directly into the build script
-	will work equally well, because they're just hex anyway. If not using
-	!geckocodelist, make sure your Gecko codeset begins with "00d0c0de 00d0c0de"
-	and ends with "f0000000 00000000".
+    Compiles the Gecko codelist text file, then adds the resulting binary to
+    Melee memory. Gecko codelists have their own format that is not covered
+    here. This command is for convenience purposes only for those using Gecko
+    codelist files, but adding your Gecko codes directly into the build script
+    will work equally well, because they're just hex anyway. If not using
+    !geckocodelist, make sure your Gecko codeset begins with "00d0c0de 00d0c0de"
+    and ends with "f0000000 00000000".
 !string "This is a text string"
-	Adds a raw ASCII text string to Melee memory.
+    Adds a raw ASCII text string to Melee memory. Escape characters are honored,
+    so using \n in a text string will appropriately write 0xa into memory.
 !asm ... !asmend
-	Compiles the PPC ASM and adds the resulting binary to Melee memory.
+    Compiles the PPC ASM and adds the resulting binary to Melee memory.
 !c2 80380580 ... !c2end
-	Compiles the PPC ASM and wraps it in a Gecko C2 code, then adds the
-	resulting binary to Melee memory.
+    Compiles the PPC ASM and wraps it in a Gecko C2 code, then adds the
+    resulting binary to Melee memory.
 !begin
-	Optionally denotes where in the current file the build script begins.
-	Anything before this line is ignored by the compiler. If not specified, the
-	build script begins on the first line of the file.
+    Optionally denotes where in the current file the build script begins.
+    Anything before this line is ignored by the compiler. If not specified, the
+    build script begins on the first line of the file.
 !end
-	Optionally denotes where in the current file the build script ends. Anything
-	after this line is ignored by the compiler. If not specified, the build
-	script ends on the last line of the file.
+    Optionally denotes where in the current file the build script ends. Anything
+    after this line is ignored by the compiler. If not specified, the build
+    script ends on the last line of the file.
 !echo "message"
-	Prints a message to the console during compilation.
+    Prints a message to the console during compilation.
 !macro macro_name ... !macroend
-	Defines a macro of script lines that can be applied anywhere.
+    Defines a macro of script lines that can be applied anywhere.
 !define alias_name ...
-	Defines an alias. Lets you use [alias_name] in your script and it will be
-	replaced with the contents of the alias before the script line is even
-	processed. For example, "!define codeset_loc 80465000" will later let you
-	write "!loc [codeset_loc]" and it will be parsed as "!loc 80465000".
+    Defines an alias. Lets you use [alias_name] in your script and it will be
+    replaced with the contents of the alias before the script line is even
+    processed. For example, "!define codeset_loc 80465000" will later let you
+    write "!loc [codeset_loc]" and it will be parsed as "!loc 80465000".
 !blockorder 0 1 2...
     Changes the order in which blocks are written to the GCI file. When Melee
     writes save data, the blocks can be written out of order, and sometimes the

--- a/doc/basics.txt
+++ b/doc/basics.txt
@@ -81,3 +81,10 @@ unique ways.
 	replaced with the contents of the alias before the script line is even
 	processed. For example, "!define codeset_loc 80465000" will later let you
 	write "!loc [codeset_loc]" and it will be parsed as "!loc 80465000".
+!blockorder 0 1 2...
+    Changes the order in which blocks are written to the GCI file. When Melee
+    writes save data, the blocks can be written out of order, and sometimes the
+    same block is written twice. This command lets you replicate that behavior,
+    although it shouldn't affect the way Melee loads the data. You must specify
+    10 total block numbers (from 0 to 9, inclusive), and those blocks will be
+    written to the GCI in that order.

--- a/doc/usage.txt
+++ b/doc/usage.txt
@@ -7,3 +7,5 @@ script_path    The path to the MGC script file you want to compile.
 --nopack       Do not pack the GCI, so you can inspect the outputted data.
 --silent       Suppress command line output, except for fatal errors.
 --debug        Output extra information while compiling and on errors.
+
+You can omit script_path to pack or unpack a GCI without changing its content.

--- a/melee-gci-compiler.py
+++ b/melee-gci-compiler.py
@@ -19,6 +19,8 @@ script_path    The path to the MGC script file you want to compile.
 --nopack       Do not pack the GCI, so you can inspect the outputted data.
 --silent       Suppress command line output, except for fatal errors.
 --debug        Output extra information while compiling and on errors.
+
+You can omit script_path to pack or unpack a GCI without changing its content.
 """
 
 

--- a/melee-gci-compiler.py
+++ b/melee-gci-compiler.py
@@ -3,6 +3,7 @@
    MGC script files"""
 
 import sys, getopt
+import hashlib
 from pathlib import Path
 from mgc import compiler
 import mgc.logger as logger
@@ -79,6 +80,8 @@ def main(argv):
         except Exception as e:
             if debug: raise
             else: log('ERROR', f"Couldn't write GCI file: {e}")
+    md5 = hashlib.md5(gci_data).hexdigest()
+    log('INFO', f"MD5: {md5}")
     log('INFO', "Successfully finished all tasks")
     _cleanup(script_path)
     sys.exit()

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -285,7 +285,7 @@ def _cmd_process_geckocodelist(data, mgcfile, line_number):
     _write_data(geckocodelist_files[file].filedata, mgcfile, line_number)
     return
 def _cmd_process_string(data, mgcfile, line_number):
-    _write_data(bytearray(data[0], encoding='ascii'), mgcfile, line_number)
+    _write_data(bytearray(bytes(data[0], 'utf-8').decode("unicode_escape"), encoding='ascii'), mgcfile, line_number)
     return
 def _cmd_process_asm(data, mgcfile, line_number):
     asm_block_num = int(data[0])

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -242,6 +242,8 @@ def _check_write_history(write_table, mgc_file, line_number):
 
 def _process_bin(data, mgcfile, line_number):
     data_hex = format(int(data, 2), 'x')
+    if len(data_hex) % 2 > 0:
+        data_hex = '0' + data_hex
     _process_hex(data_hex, mgcfile, line_number)
     return
 def _process_hex(data, mgcfile, line_number):

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -238,14 +238,13 @@ def _process_warning(data, mgcfile, line_number):
     return
 def _process_error(data, mgcfile, line_number):
     raise CompileError(data, mgcfile, line_number)
-    return
 def _process_macro(data, mgcfile, line_number):
     macro_name = data.name
     macro_count = data.count
     if not macro_name in mgc_file.macros:
         raise CompileError(f"Undefined macro: {macro_name}, mgcfile, line_number")
     op_list = mgc_file.macros[macro_name]
-    for count in range(macro_count):
+    for _ in range(macro_count):
         for op in op_list:
             OPCODE_FUNCS[op.codetype](op.data, mgcfile, line_number)
 

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -308,6 +308,27 @@ def _cmd_process_geckocodelist(data, mgcfile, line_number):
 def _cmd_process_string(data, mgcfile, line_number):
     _write_data(bytearray(bytes(data[0], 'utf-8').decode("unicode_escape"), encoding='ascii'), mgcfile, line_number)
     return
+def _cmd_process_fill(data, mgcfile, line_number):
+    # TODO: This line format check should happen in lineparser.py
+    if data[1][0] == '%':
+        if len(data[1][0] == 1): log('ERROR', "Syntax error")
+        data[1] = data[1][1:]
+        try:
+            int(data[1], 2)
+            padding = len(data[1]) % 8
+            if padding > 0:
+                log('WARNING', "Fill data is not byte-aligned; may produce undesirable results")
+            _process_bin(data[1] * data[0], mgcfile, line_number)
+        except ValueError:
+            log('ERROR', "Syntax error")
+        try:
+            int(data[1], 16)
+            if data[1] % 2 != 0:
+                log('WARNING', "Fill data is not byte-aligned; may produce undesirable results")
+            _process_hex(data[1] * data[0], mgcfile, line_number)
+        except ValueError:
+            log('ERROR', "Syntax error")
+    _process_hex(data[1] * data[0], mgcfile, line_number)
 def _cmd_process_asm(data, mgcfile, line_number):
     asm_block_num = int(data[0])
     _process_hex(mgcfile.asm_blocks[asm_block_num], mgcfile, line_number)
@@ -369,6 +390,7 @@ COMMAND_FUNCS = {
     'file': _cmd_process_file,
     'geckocodelist': _cmd_process_geckocodelist,
     'string': _cmd_process_string,
+    'fill': _cmd_process_fill,
     'asm': _cmd_process_asm,
     'asmend': _cmd_process_asmend,
     'c2': _cmd_process_c2,

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -91,10 +91,10 @@ def compile(root_mgc_path, input_gci=None, silent=False, debug=False, nopack=Fal
     if block_order:
         input_gci.block_order = block_order
         input_gci.reorder_blocks()
-    input_gci.recompute_checksums()
     # Done with everything except packing, write the patch table
     for address, data in patch_table:
         input_gci.raw_bytes[address:address+len(data)] = data
+    input_gci.recompute_checksums()
     if not nopack:
         log('INFO', "Packing GCI")
         input_gci.pack()

--- a/mgc/compiler.py
+++ b/mgc/compiler.py
@@ -311,26 +311,8 @@ def _cmd_process_string(data, mgcfile, line_number):
     _write_data(bytearray(bytes(data[0], 'utf-8').decode("unicode_escape"), encoding='ascii'), mgcfile, line_number)
     return
 def _cmd_process_fill(data, mgcfile, line_number):
-    # TODO: This line format check should happen in lineparser.py
-    if data[1][0] == '%':
-        if len(data[1][0] == 1): log('ERROR', "Syntax error")
-        data[1] = data[1][1:]
-        try:
-            int(data[1], 2)
-            padding = len(data[1]) % 8
-            if padding > 0:
-                log('WARNING', "Fill data is not byte-aligned; may produce undesirable results")
-            _process_bin(data[1] * data[0], mgcfile, line_number)
-        except ValueError:
-            log('ERROR', "Syntax error")
-        try:
-            int(data[1], 16)
-            if data[1] % 2 != 0:
-                log('WARNING', "Fill data is not byte-aligned; may produce undesirable results")
-            _process_hex(data[1] * data[0], mgcfile, line_number)
-        except ValueError:
-            log('ERROR', "Syntax error")
     _process_hex(data[1] * data[0], mgcfile, line_number)
+    return
 def _cmd_process_asm(data, mgcfile, line_number):
     asm_block_num = int(data[0])
     _process_hex(mgcfile.asm_blocks[asm_block_num], mgcfile, line_number)

--- a/mgc/lineparser.py
+++ b/mgc/lineparser.py
@@ -25,6 +25,7 @@ COMMANDS = {
     'file': ['str'],
     'geckocodelist': ['str'],
     'string': ['str'],
+    'fill': ['int', 'var'],
     'asm': [],
     'asmend': [],
     'c2': ['hex'],

--- a/mgc/lineparser.py
+++ b/mgc/lineparser.py
@@ -125,7 +125,6 @@ def parse_opcodes(script_line):
                 quote_args = quote_args.split('"')
                 command_args = []
                 for index, arg in enumerate(quote_args):
-                    arg = arg.strip()
                     if arg == '': continue
                     if index % 2 == 0: command_args += arg.split(' ')
                     else: command_args.append('"' + arg + '"')

--- a/mgc/lineparser.py
+++ b/mgc/lineparser.py
@@ -18,6 +18,7 @@ COMMANDS = {
     # 'str': A string wrapped in quotes, eg. for file names
     'loc': ['hex'],
     'gci': ['hex'],
+    'patch': ['hex'],
     'add': ['hex'],
     'src': ['str'],
     'asmsrc': ['str'],

--- a/mgc/lineparser.py
+++ b/mgc/lineparser.py
@@ -33,7 +33,9 @@ COMMANDS = {
     'echo': ['str'],
     'macro': ['var'],
     'macroend': [],
-    'define': ['var', 'var']
+    'define': ['var', 'var'],
+    'blockorder': ['int', 'int', 'int', 'int', 'int',
+                   'int', 'int', 'int', 'int', 'int']
     }
 
 aliases = {}
@@ -179,6 +181,10 @@ def _parse_command(command):
                 except ValueError:
                     return [Operation('ERROR', f"Command argument {index+1} must be a hex value")]
             elif expected_type == 'var':
+                typed_args.append(arg)
+            elif expected_type == 'int':
+                if arg[:2] == '0x': arg = int(arg, 16)
+                else: arg = int(arg)
                 typed_args.append(arg)
             else:
                 raise ValueError("Unsupported command argument type")

--- a/mgc/lineparser.py
+++ b/mgc/lineparser.py
@@ -16,6 +16,7 @@ COMMANDS = {
     # 'int': A decimal number (eg. 10) or hex in 0x notation (eg. 0xa)
     # 'var': Any legal string, eg. for defining a macro
     # 'str': A string wrapped in quotes, eg. for file names
+    # 'data': Hex or binary data
     'loc': ['hex'],
     'gci': ['hex'],
     'patch': ['hex'],
@@ -25,7 +26,7 @@ COMMANDS = {
     'file': ['str'],
     'geckocodelist': ['str'],
     'string': ['str'],
-    'fill': ['int', 'var'],
+    'fill': ['int', 'data'],
     'asm': [],
     'asmend': [],
     'c2': ['hex'],
@@ -63,35 +64,21 @@ def parse_opcodes(script_line):
 
     # Check if line is hex
     if script_line[0] in string.hexdigits:
-        # Remove all whitespace
-        script_line = script_line.translate(dict.fromkeys(map(ord, string.whitespace)))
-        try:
-            int(script_line, 16)
-            padding = len(script_line) % 2
-            if padding > 0:
-                op_list.append(Operation('WARNING', 'Hex data is not byte-aligned; padding to the nearest byte'))
-                script_line = '0' + script_line
+        script_line, warnings = _format_hexdata(script_line)
+        op_list += warnings
+        if script_line:
             op_list.append(Operation('HEX', script_line))
-        except ValueError:
-            op_list.append(SYNTAX_ERROR)
+
     # If we're not hex, then 1-character strings (eg. %, +, !) always error
     elif len(script_line) == 1:
         op_list.append(SYNTAX_ERROR)
+
     # Check if line is binary
     elif script_line[0] == '%':
-        # Remove % character
-        script_line = script_line[1:]
-        # Remove all whitespace
-        script_line = script_line.translate(dict.fromkeys(map(ord, string.whitespace)))
-        try:
-            int(script_line, 2)
-            padding = len(script_line) % 8
-            if padding > 0:
-                op_list.append(Operation('WARNING', 'Binary data is not byte-aligned; padding to the nearest byte'))
-                script_line = '0' * (8 - padding) + script_line
+        script_line, warnings = _format_bindata(script_line)
+        op_list += warnings
+        if script_line:
             op_list.append(Operation('BIN', script_line))
-        except ValueError:
-            op_list.append(SYNTAX_ERROR)
 
     # Check if line is a macro
     elif script_line[0] == '+':
@@ -139,13 +126,47 @@ def parse_opcodes(script_line):
             validated_commands = _parse_command(Command(command_name, command_args))
             op_list += validated_commands
 
-
     # We've exhausted all opcodes
     else:
         op_list.append(SYNTAX_ERROR)
 
-
     return op_list
+
+def _format_hexdata(data):
+    """Takes a string of hex data and returns a formatted version along with any
+       warning or error operations that resulted."""
+    op_list = []
+    # Remove all whitespace
+    data = data.translate(dict.fromkeys(map(ord, string.whitespace)))
+    try:
+        int(data, 16)
+        padding = len(data) % 2
+        if padding > 0:
+            op_list.append(Operation('WARNING', 'Hex data is not byte-aligned; padding to the nearest byte'))
+            data = '0' + data
+    except ValueError:
+        data = ''
+        op_list.append(SYNTAX_ERROR)
+    return (data, op_list)
+
+def _format_bindata(data):
+    """Takes a string of binary data and returns a formatted version
+       along with any warning or error operations that resulted."""
+    op_list = []
+    # Remove % character
+    data = data[1:]
+    # Remove all whitespace
+    data = data.translate(dict.fromkeys(map(ord, string.whitespace)))
+    try:
+        int(data, 2)
+        padding = len(data) % 8
+        if padding > 0:
+            op_list.append(Operation('WARNING', 'Binary data is not byte-aligned; padding to the nearest byte'))
+            data = '0' * (8 - padding) + data
+    except ValueError:
+        data = ''
+        op_list.append(SYNTAX_ERROR)
+    return (data, op_list)
 
 def _parse_command(command):
     """Takes a Command and validates the arguments and data types.
@@ -165,6 +186,7 @@ def _parse_command(command):
             return [Operation('ERROR', f"Command expected {expected_arg_count} arg(s) but received {arg_count}")]
     untyped_args = command.args
     typed_args = []
+    op_list = []
     expected_types = COMMANDS[command.name] # List of arg types for this Command
     if expected_types != None:
         for index, arg in enumerate(untyped_args):
@@ -188,9 +210,34 @@ def _parse_command(command):
                 if arg[:2] == '0x': arg = int(arg, 16)
                 else: arg = int(arg)
                 typed_args.append(arg)
+            elif expected_type == 'data':
+                # Check if line is hex
+                if arg[0] in string.hexdigits:
+                    arg, warnings = _format_hexdata(arg)
+                    op_list += warnings
+                    if not arg:
+                        return [Operation('ERROR', f"Command argument {index+1} must be hex or binary data")]
+                    typed_args.append(arg)
+                # If we're not hex, then 1-character strings (eg. %, +, !) always error
+                elif len(arg) == 1:
+                    return [Operation('ERROR', f"Command argument {index+1} must be hex or binary data")]
+                # Check if line is binary
+                elif arg[0] == '%':
+                    arg, warnings = _format_bindata(arg)
+                    op_list += warnings
+                    if not arg:
+                        return [Operation('ERROR', f"Command argument {index+1} must be hex or binary data")]
+                    arg = format(int(arg, 2), 'x')
+                    if len(arg) % 2 > 0:
+                        arg = '0' + arg
+                    typed_args.append(arg)
+                else:
+                    return [Operation('ERROR', f"Command argument {index+1} must be hex or binary data")]
+
             else:
                 raise ValueError("Unsupported command argument type")
     else:
         typed_args = untyped_args
 
-    return [Operation('COMMAND', Command(command.name, typed_args))]
+    op_list.append(Operation('COMMAND', Command(command.name, typed_args)))
+    return op_list

--- a/mgc/mgc_file.py
+++ b/mgc/mgc_file.py
@@ -137,8 +137,8 @@ class MGCFile(File):
                 multiline_comment = True
             # Trim whitespace
             line = line.strip()
-            # Consolidate multiple spaces into one space
-            line = re.sub(r'\s+', ' ', line)
+            # Consolidate multiple spaces into one space, unless in quotes
+            line = re.sub(r'\s+(?=([^"]*"[^"]*")*[^"]*$)', ' ', line)
 
             # Look for !begin and !end
             op_list = parse_opcodes(line)


### PR DESCRIPTION
After this merge, the release version of Melee GCI Compiler will be updated to version `1.1.0`.

# New Features
## !blockorder
When Melee performs a save, the layout of the blocks in the save file can change. `!blockorder` allows you to change the block layout in your compiled GCI in case you are trying to match the layout of an existing Melee save, as is the case with the 20XXTE source port (or if there is a specific functionality to the block layout that has not yet been discovered).
## !patch
Like `!gci`, but writing data while in patch mode defers that data from being written until the very end of compilation, right before the GCI is packed. If `!blockorder` is used, block reordering happens before this as well, so the address specified by `!patch` is absolute and does not "follow" any blocks around. Using `!loc` or `!gci` after `!patch` will disable patch mode for following data writes.
## !fill
Writes the pattern in the second argument the number of times specified in the first argument. The pattern can be hex (eg. ff) or binary (eg. %11111111). The pattern can be any number of bytes long.

* `!fill 0x80 ff` will fill 0x80 (128) bytes with `ff`.
* `!fill 0x80 f0f0` will fill 0x80 half-words (256 bytes) with `f0f0`.

# Fixes/Changes
* Fixed a bug where whitespace inside of a `!string` command would be trimmed, resulting in the output being different from expected.
* `!string` now has any escape characters processed, eg. `\n` is written to memory as the byte `0xa`, rather than being written literally.
* Fixed a bug where writing binary data, eg. `%00000001`, would not always correctly pad to be byte-aligned.
* An MD5 hash was added to the compiler output so that the integrity of the output can be more easily verified. This is useful if you are restructuring your script but want to make sure the contents of the GCI output doesn't change.
* Added some additional details to the docs and usage text.